### PR TITLE
Ruby PKGBUILD - remove libffi flags in build

### DIFF
--- a/mingw-w64-ruby24/PKGBUILD
+++ b/mingw-w64-ruby24/PKGBUILD
@@ -42,9 +42,7 @@ prepare() {
 
 build() {
 
-  local FFI_INC=$(pkg-config --cflags libffi)
-  CPPFLAGS+=" -DFD_SETSIZE=2048 ${FFI_INC}"
-  CFLAGS+=" ${FFI_INC}"
+  CPPFLAGS+=" -DFD_SETSIZE=2048"
 
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"

--- a/mingw-w64-ruby25/PKGBUILD
+++ b/mingw-w64-ruby25/PKGBUILD
@@ -44,9 +44,7 @@ prepare() {
 
 build() {
 
-  local FFI_INC=$(pkg-config --cflags libffi)
-  CPPFLAGS+=" -DFD_SETSIZE=2048 ${FFI_INC}"
-  CFLAGS+=" ${FFI_INC}"
+  CPPFLAGS+=" -DFD_SETSIZE=2048"
 
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
See #7