### PR TITLE
Add ragel to PKGBUILD depends

### DIFF
--- a/mingw-w64-ruby24/PKGBUILD
+++ b/mingw-w64-ruby24/PKGBUILD
@@ -13,6 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-libyaml"
          "${MINGW_PACKAGE_PREFIX}-openssl<1.1"
+         "${MINGW_PACKAGE_PREFIX}-ragel"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver}.tar.bz2"

--- a/mingw-w64-ruby25/PKGBUILD
+++ b/mingw-w64-ruby25/PKGBUILD
@@ -16,6 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-libyaml"
          "${MINGW_PACKAGE_PREFIX}-openssl>=1.1"
+         "${MINGW_PACKAGE_PREFIX}-ragel"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=("https://cache.ruby-lang.org/pub/ruby/snapshot.tar.xz"


### PR DESCRIPTION
ragel package is required to build a json extension/so, otherwise only a 'pure ruby' implementation is available.