### PR TITLE
CI: Add autotools to build dependencies

### DIFF
--- a/mingw-w64-ruby-head/PKGBUILD
+++ b/mingw-w64-ruby-head/PKGBUILD
@@ -11,7 +11,7 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://www.ruby-lang.org/en"
 license=("BSD, custom")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" autoconf automake libtool)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-libffi"

--- a/mingw-w64-ruby-head/PKGBUILD
+++ b/mingw-w64-ruby-head/PKGBUILD
@@ -83,3 +83,4 @@ package() {
       ${pkgdir}${MINGW_PREFIX}/bin/
   done
 }
+


### PR DESCRIPTION
... because the head version runs autoreconf and it is not longer installed per default on Github Actions.